### PR TITLE
Update sun-emitter.js

### DIFF
--- a/classes/sun/sun-emitter.js
+++ b/classes/sun/sun-emitter.js
@@ -8,8 +8,12 @@ function setDateout(fn, d) {
   return setTimeout(fn, t);
 }
 
+function isFutureDate(d) {
+  return new Date().getTime() <= new Date(d).getTime();
+}
+
 function isValidDate(d) {
-  return d instanceof Date && !isNaN(d);
+  return d instanceof Date && !isNaN(d) && isFutureDate(d);
 }
 
 class SunEmitter extends EventEmitter {


### PR DESCRIPTION
added check if dateout is in the future, 
in my instance sun_nadir was being added with a past date and spamming in logs 
 macrozilla: starting dateout for sun_nadir with a wrong datetime (the previous day one)