### PR TITLE
Update index.css

### DIFF
--- a/static/views/editor-structogram/index.css
+++ b/static/views/editor-structogram/index.css
@@ -436,12 +436,10 @@ div#throwtrashhere:hover{
     line-height: 75px;
     margin-top: 0;
     margin-bottom: 0;
-    width: initial !important;
 }
 
 .macrointerface > .cardplaceholder.filled{
     line-height: initial;
-    width: initial;
 }
 
 .cardplaceholder.executable > .preview{


### PR DESCRIPTION
remove width initial, results in blocks growing wide enough to display under the sidebar, making drop targets unexpectedly active. without, cards grow to [100%](https://github.com/bewee/macrozilla/blob/master/static/views/editor-structogram/index.css#L483)