### PR TITLE
Add unknown class

### DIFF
--- a/classes/unknown/client.js
+++ b/classes/unknown/client.js
@@ -1,0 +1,13 @@
+(() => {
+  class UnknownClass {
+
+    constructor(handler) {
+      const load_element = handler.addLoadCard(null, () => {});
+      load_element.setShutdownText('Unknown');
+      load_element.setAttribute('unknown', 'true');
+    }
+
+  }
+
+  window.exports = UnknownClass;
+})();

--- a/classes/unknown/server.js
+++ b/classes/unknown/server.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = {
+};

--- a/static/views/editor-structogram/index.css
+++ b/static/views/editor-structogram/index.css
@@ -447,6 +447,14 @@ div#throwtrashhere:hover{
     color: #4a4a4a;
 }
 
+.macroblock[unknown]{
+    background: #333;
+}
+
+.macroblock.macrocard[unknown] .blockdescr{
+    color: #fff;
+}
+
 .macrointerface > .cardplaceholder, .macrointerface > .cardplaceholder.filled{
     position: relative;
     border: 1px dotted gray;

--- a/static/views/editor-structogram/index.js
+++ b/static/views/editor-structogram/index.js
@@ -104,10 +104,14 @@
       // load headers from serialization
       for (const b of serialization) {
         let be = null;
-        if ('qualifier' in b)
+        if (!(b.type in this.classHandlers))
+          be = Object.values(this.classHandlers.unknown.buildingelements)[0];
+        else if ('qualifier' in b)
           be = this.classHandlers[b.type].buildingelements[b.qualifier];
         else
           be = Object.values(this.classHandlers[b.type].buildingelements)[0];
+        if (!be)
+          be = Object.values(this.classHandlers.unknown.buildingelements)[0];
         if (be.hasAbility('header') && (be.obligatory || b.ability === 'header')) {
           const be_copy = be.copyFromSerialization(b, maxid);
           be_copy.obligatory = be.obligatory;

--- a/static/views/editor/parameter.js
+++ b/static/views/editor/parameter.js
@@ -122,10 +122,16 @@
     }
 
     loadFromSerialization_(serialization, maxid) {
-      const paramhandler = this.editor.classHandlers[serialization.type];
+      let paramhandler;
+      if (!(serialization.type in this.editor.classHandlers))
+        paramhandler = this.editor.classHandlers.unknown;
+      else
+        paramhandler = this.editor.classHandlers[serialization.type];
       let param = Object.values(paramhandler.buildingelements)[0];
       if (serialization.qualifier)
         param = paramhandler.buildingelements[serialization.qualifier];
+      if (!param)
+        param = Object.values(this.editor.classHandlers.unknown.buildingelements)[0];
       const cparam = param.copyFromSerialization(serialization, maxid);
       this.placeCard(cparam);
     }


### PR DESCRIPTION
This stops the editor from crashing whenever there is a block/card of unknown class or identifier. The unknown blocks/cards get marked "shutdown", so their serialization will be kept as it has been during load.